### PR TITLE
Bugfix/token refresh

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -67,7 +67,11 @@ const buildEntitlementsByUser =
       provide: APP_INITIALIZER,
       multi: true,
       deps: [ OAuthService ],
-      useFactory: (oAuthService: OAuthService) => () => oAuthService.loadDiscoveryDocumentAndTryLogin()
+      useFactory: (oAuthService: OAuthService) => () => {
+        return oAuthService.loadDiscoveryDocumentAndTryLogin().then(() => {
+          return oAuthService.setupAutomaticSilentRefresh();
+        });
+      }
     },
     {
       provide: CONDITIONS,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -48,9 +48,4 @@ export const authConfig: AuthConfig = {
   showDebugInformation: true,
 
   logoutUrl: '${PROTOCOL}//${HOSTNAME}:${PORT}${PATHNAME}${AUTH_REDIRECT_PAGE}',
-
-  // Explicitly add flag to make possible refresh of the token
-  // without going through login flow
-  useSilentRefresh: true,
-  silentRefreshTimeout: 5000,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -37,7 +37,7 @@ export const authConfig: AuthConfig = {
 
   // The SPA's id. The SPA is registered with this id at the auth-server
   clientId: 'bb-web-client',
-
+  
   // Just needed if your auth server demands a secret. In general, this
   // is a sign that the auth server is not configured with SPAs in mind
   // and it might not enforce further best practices vital for security
@@ -56,11 +56,6 @@ export const authConfig: AuthConfig = {
   showDebugInformation: true,
 
   logoutUrl: document.location.origin + '/login',
-
-  // Explicitly add flag to make possible refresh of the token
-  // without going through login flow
-  useSilentRefresh: true,
-  silentRefreshTimeout: 5000,
 };
 
 /*


### PR DESCRIPTION
The repo in its current state was not refreshing the token. So after x minutes, new API calls would be failing.

When adding `oAuthService.setupAutomaticSilentRefresh();` a refresh was triggered, however a complete refresh of the page was done

Only after removing `useSilentRefresh: true` all worked as expected. But, to be honest, not 100% sure why, could not find documentation for this behaviour.