### PR TITLE
Add example for journey extension

### DIFF
--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.html
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.html
@@ -1,0 +1,5 @@
+<bb-transactions-journey>
+    <ng-template bbTransactionAdditionalDetails let-transaction>
+      <span class="transaction-additional-details">{{ transaction.counterPartyAccountNumber}}</span>
+    </ng-template>
+</bb-transactions-journey>

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.html
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.html
@@ -1,5 +1,12 @@
 <bb-transactions-journey>
-    <ng-template bbTransactionAdditionalDetails let-transaction>
-      <span class="transaction-additional-details">{{ transaction.counterPartyAccountNumber}}</span>
+    <ng-template 
+      bbTransactionAdditionalDetails 
+      let-accountNumber="counterPartyAccountNumber"
+      let-additions="additions || {}"
+    >
+      <span class="transaction-account-number">{{ accountNumber }}</span>
+      <span class="transaction-my-addition" *ngIf="additions['myAddition']">
+        {{ additions["myAddition"] }}
+      </span>
     </ng-template>
 </bb-transactions-journey>

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.scss
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.scss
@@ -1,3 +1,7 @@
-.transaction-additional-details {
+.transaction-account-number {
     display: block;
+}
+
+.transaction-my-addition {
+    font-weight: 600;
 }

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.scss
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.scss
@@ -1,0 +1,3 @@
+.transaction-additional-details {
+    display: block;
+}

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.ts
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.component.ts
@@ -1,0 +1,9 @@
+import { Component } from "@angular/core";
+
+@Component({
+    selector: 'app-transactions-journey-bundle',
+    templateUrl: './transactions-journey-bundle.component.html',
+    styleUrls: ['./transactions-journey-bundle.component.scss'],
+  })
+  export class TransactionsJourneyBundleComponent { }
+  

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import {
   TransactionsJourneyConfiguration,
   TransactionsJourneyModule,
@@ -6,18 +6,7 @@ import {
 } from '@libs/transactions';
 import { environment } from '../../environments/environment';
 import { JourneyCommunicationService } from '../services/journey-communication.service';
-
-@Component({
-  selector: 'app-transactions-journey-bundle',
-  template: `
-    <bb-transactions-journey>
-        <ng-template bbTransactionAdditionalDetails let-transaction>
-          {{ transaction.counterPartyAccountNumber}}
-        </ng-template>
-    </bb-transactions-journey>
-  `,
-})
-export class TransactionsJourneyBundleComponent { }
+import { TransactionsJourneyBundleComponent } from './transactions-journey-bundle.component';
 
 @NgModule({
   imports: [

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
@@ -1,6 +1,4 @@
-import { CommonModule } from '@angular/common';
 import { Component, NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
 import {
   TransactionsJourneyConfiguration,
   TransactionsJourneyModule,
@@ -23,8 +21,6 @@ export class TransactionsJourneyBundleComponent { }
 
 @NgModule({
   imports: [
-    CommonModule,
-    RouterModule,
     TransactionsJourneyModule.forRoot({ 
       route: {
         path: '',

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component, NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import {
@@ -22,6 +23,7 @@ export class TransactionsJourneyBundleComponent { }
 
 @NgModule({
   imports: [
+    CommonModule,
     RouterModule,
     TransactionsJourneyModule.forRoot({ 
       route: {

--- a/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
+++ b/apps/golden-sample-app/src/app/transactions/transactions-journey-bundle.module.ts
@@ -1,4 +1,5 @@
-import { NgModule } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import {
   TransactionsJourneyConfiguration,
   TransactionsJourneyModule,
@@ -7,8 +8,29 @@ import {
 import { environment } from '../../environments/environment';
 import { JourneyCommunicationService } from '../services/journey-communication.service';
 
+@Component({
+  selector: 'app-transactions-journey-bundle',
+  template: `
+    <bb-transactions-journey>
+        <ng-template bbTransactionAdditionalDetails let-transaction>
+          {{ transaction.counterPartyAccountNumber}}
+        </ng-template>
+    </bb-transactions-journey>
+  `,
+})
+export class TransactionsJourneyBundleComponent { }
+
 @NgModule({
-  imports: [TransactionsJourneyModule.forRoot()],
+  imports: [
+    RouterModule,
+    TransactionsJourneyModule.forRoot({ 
+      route: {
+        path: '',
+        component: TransactionsJourneyBundleComponent
+      } 
+    })
+  ],
+  declarations: [TransactionsJourneyBundleComponent],
   providers: [
     {
       provide: TransactionsJourneyConfiguration,

--- a/apps/golden-sample-app/src/environments/environment.ts
+++ b/apps/golden-sample-app/src/environments/environment.ts
@@ -55,8 +55,6 @@ export const authConfig: AuthConfig = {
   showDebugInformation: true,
 
   logoutUrl: document.location.origin + '/logout',
-  useSilentRefresh: true,
-  silentRefreshTimeout: 5000,
 };
 
 /*

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
@@ -18,11 +18,7 @@
       *ngIf="additionsDetailsTpl"
       data-slot="additionsDetails"
       [ngTemplateOutlet]="additionsDetailsTpl"
-      [ngTemplateOutletContext]="{
-        additions: transaction.additions,
-        merchant: transaction.merchant,
-        counterPartyAccountNumber: transaction.counterPartyAccountNumber
-      }"
+      [ngTemplateOutletContext]="additionsDetailsContext"
     ></ng-container>
   </span>
 </span>

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
@@ -18,7 +18,11 @@
       *ngIf="additionsDetailsTpl"
       data-slot="additionsDetails"
       [ngTemplateOutlet]="additionsDetailsTpl"
-      [ngTemplateOutletContext]="{ $implicit: transaction }"
+      [ngTemplateOutletContext]="{
+        additions: transaction.additions,
+        merchant: transaction.merchant,
+        counterPartyAccountNumber: transaction.counterPartyAccountNumber
+      }"
     ></ng-container>
   </span>
 </span>

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
@@ -12,9 +12,8 @@
   <span class="transactions-item__counterParty">{{
     transaction.counterPartyName
   }}</span>
-  <span class="transactions-item__transactionType">{{ transaction.type }}</span>
-
-  <span class="transactions-item__additionalDetails">
+  <span class="transactions-item__transactionType">
+    {{ transaction.type }}
     <ng-container
       *ngIf="additionsDetailsTpl"
       data-slot="additionsDetails"
@@ -22,7 +21,6 @@
       [ngTemplateOutletContext]="{ $implicit: transaction }"
     ></ng-container>
   </span>
-
 </span>
 <span
   class="transactions-item__amount"

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.html
@@ -9,10 +9,20 @@
   transaction.valueDate | date: 'MMM. d'
 }}</span>
 <span class="transactions-item__description">
-  <span class="transactions-item__merchant">{{
-    transaction.merchant?.name
+  <span class="transactions-item__counterParty">{{
+    transaction.counterPartyName
   }}</span>
   <span class="transactions-item__transactionType">{{ transaction.type }}</span>
+
+  <span class="transactions-item__additionalDetails">
+    <ng-container
+      *ngIf="additionsDetailsTpl"
+      data-slot="additionsDetails"
+      [ngTemplateOutlet]="additionsDetailsTpl"
+      [ngTemplateOutletContext]="{ $implicit: transaction }"
+    ></ng-container>
+  </span>
+
 </span>
 <span
   class="transactions-item__amount"

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.scss
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.scss
@@ -27,7 +27,8 @@
   flex: 1;
 }
 
-.transactions-item__transactionType {
+.transactions-item__transactionType,
+.transactions-item__additionalDetails {
   font-size: .8rem;
   color: gray;
 }

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.scss
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.scss
@@ -27,8 +27,7 @@
   flex: 1;
 }
 
-.transactions-item__transactionType,
-.transactions-item__additionalDetails {
+.transactions-item__transactionType {
   font-size: .8rem;
   color: gray;
 }

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
@@ -4,8 +4,10 @@ import {
   Input,
   OnChanges,
   SimpleChanges,
+  TemplateRef,
 } from '@angular/core';
 import { TransactionItem } from '@backbase/data-ang/transactions';
+import { TransactionsJourneyConfiguration } from '../../services/transactions-journey-config.service';
 
 @Component({
   selector: 'bb-transaction-item',
@@ -17,9 +19,17 @@ export class TransactionItemComponent implements OnChanges {
   @Input() transaction!: TransactionItem;
   public amount = 0;
   public isAmountPositive = true;
+  public additionsDetailsTpl: TemplateRef<any> | undefined;
+  
+  constructor(private readonly configService: TransactionsJourneyConfiguration) {
+    this.additionsDetailsTpl = this.configService.additionalDetailsTpl;
 
+  }
+  
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['transaction']) {
+    console.warn('transaction', this.transaction);
+
       this.amount = Number(
         this.transaction.transactionAmountCurrency.amount ?? 0
       );

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
@@ -7,6 +7,7 @@ import {
   TemplateRef,
 } from '@angular/core';
 import { TransactionItem } from '@backbase/data-ang/transactions';
+import { AdditionalDetailsContext } from '../../directives/transaction-additional-details.directive';
 import { TransactionsJourneyConfiguration } from '../../services/transactions-journey-config.service';
 
 @Component({
@@ -19,7 +20,7 @@ export class TransactionItemComponent implements OnChanges {
   @Input() transaction!: TransactionItem;
   public amount = 0;
   public isAmountPositive = true;
-  public additionsDetailsTpl: TemplateRef<any> | undefined;
+  public additionsDetailsTpl: TemplateRef<AdditionalDetailsContext> | undefined;
   
   constructor(private readonly configService: TransactionsJourneyConfiguration) {
     this.additionsDetailsTpl = this.configService.additionalDetailsTpl;
@@ -28,8 +29,6 @@ export class TransactionItemComponent implements OnChanges {
   
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['transaction']) {
-    console.warn('transaction', this.transaction);
-
       this.amount = Number(
         this.transaction.transactionAmountCurrency.amount ?? 0
       );

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
@@ -18,12 +18,9 @@ export class TransactionItemComponent implements OnChanges {
   @Input() transaction!: TransactionItem;
   public amount = 0;
   public isAmountPositive = true;
-  public additionsDetailsTpl;
+  public additionsDetailsTpl = this.configService.additionalDetailsTpl;
   
-  constructor(private readonly configService: TransactionsJourneyConfiguration) {
-    this.additionsDetailsTpl = this.configService.additionalDetailsTpl;
-
-  }
+  constructor(private readonly configService: TransactionsJourneyConfiguration) {}
   
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['transaction']) {

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
@@ -6,6 +6,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { TransactionItem } from '@backbase/data-ang/transactions';
+import { AdditionalDetailsContext } from '../../directives/transaction-additional-details.directive';
 import { TransactionsJourneyConfiguration } from '../../services/transactions-journey-config.service';
 
 @Component({
@@ -16,10 +17,19 @@ import { TransactionsJourneyConfiguration } from '../../services/transactions-jo
 })
 export class TransactionItemComponent implements OnChanges {
   @Input() transaction!: TransactionItem;
+  
   public amount = 0;
   public isAmountPositive = true;
   public additionsDetailsTpl = this.configService.additionalDetailsTpl;
   
+  get additionsDetailsContext(): AdditionalDetailsContext {
+    return {
+      additions: this.transaction.additions,
+      merchant: this.transaction.merchant,
+      counterPartyAccountNumber: this.transaction.counterPartyAccountNumber
+    }
+  }
+
   constructor(private readonly configService: TransactionsJourneyConfiguration) {}
   
   ngOnChanges(changes: SimpleChanges): void {

--- a/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
+++ b/libs/transactions/src/lib/components/transaction-item/transaction-item.component.ts
@@ -4,10 +4,8 @@ import {
   Input,
   OnChanges,
   SimpleChanges,
-  TemplateRef,
 } from '@angular/core';
 import { TransactionItem } from '@backbase/data-ang/transactions';
-import { AdditionalDetailsContext } from '../../directives/transaction-additional-details.directive';
 import { TransactionsJourneyConfiguration } from '../../services/transactions-journey-config.service';
 
 @Component({
@@ -20,7 +18,7 @@ export class TransactionItemComponent implements OnChanges {
   @Input() transaction!: TransactionItem;
   public amount = 0;
   public isAmountPositive = true;
-  public additionsDetailsTpl: TemplateRef<AdditionalDetailsContext> | undefined;
+  public additionsDetailsTpl;
   
   constructor(private readonly configService: TransactionsJourneyConfiguration) {
     this.additionsDetailsTpl = this.configService.additionalDetailsTpl;

--- a/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
+++ b/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
@@ -1,9 +1,7 @@
 import { Directive, TemplateRef } from "@angular/core";
 import { TransactionItem } from "@backbase/data-ang/transactions";
 
-export type AdditionalDetailsContext = {
-  $implicit: Pick<TransactionItem, 'additions' | 'counterPartyAccountNumber' | 'location' | 'merchant'>
-}
+export type AdditionalDetailsContext = Pick<TransactionItem, 'additions' | 'counterPartyAccountNumber' | 'merchant'>
 
 @Directive({selector: 'ng-template[bbTransactionAdditionalDetails]'})
 export class TransactionAdditionalDetailsTemplateDirective {

--- a/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
+++ b/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
@@ -1,0 +1,7 @@
+import { Directive, TemplateRef } from "@angular/core";
+
+
+@Directive({selector: 'ng-template[bbTransactionAdditionalDetails]'})
+export class TransactionAdditionalDetailsTemplateDirective {
+  constructor(public templateRef: TemplateRef<any>) {}
+}

--- a/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
+++ b/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
@@ -1,7 +1,15 @@
 import { Directive, TemplateRef } from "@angular/core";
+import { TransactionItem } from "@backbase/data-ang/transactions";
 
+export type AdditionalDetailsContext = {
+  $implicit: TransactionItem
+}
 
 @Directive({selector: 'ng-template[bbTransactionAdditionalDetails]'})
 export class TransactionAdditionalDetailsTemplateDirective {
-  constructor(public templateRef: TemplateRef<any>) {}
+  constructor(public templateRef: TemplateRef<AdditionalDetailsContext>) {}
+
+  static ngTemplateContextGuard(dir: TransactionAdditionalDetailsTemplateDirective, ctx: unknown): ctx is AdditionalDetailsContext { 
+      return true
+  };
 }

--- a/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
+++ b/libs/transactions/src/lib/directives/transaction-additional-details.directive.ts
@@ -2,7 +2,7 @@ import { Directive, TemplateRef } from "@angular/core";
 import { TransactionItem } from "@backbase/data-ang/transactions";
 
 export type AdditionalDetailsContext = {
-  $implicit: TransactionItem
+  $implicit: Pick<TransactionItem, 'additions' | 'counterPartyAccountNumber' | 'location' | 'merchant'>
 }
 
 @Directive({selector: 'ng-template[bbTransactionAdditionalDetails]'})

--- a/libs/transactions/src/lib/services/transactions-journey-config.service.ts
+++ b/libs/transactions/src/lib/services/transactions-journey-config.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, TemplateRef } from '@angular/core';
+import { AdditionalDetailsContext } from '../directives/transaction-additional-details.directive';
 
 @Injectable()
 export class TransactionsJourneyConfiguration {
   pageSize = 20;
   slimMode = true;
-  additionalDetailsTpl: TemplateRef<any> | undefined = undefined;
+  additionalDetailsTpl: TemplateRef<AdditionalDetailsContext> | undefined = undefined;
 }

--- a/libs/transactions/src/lib/services/transactions-journey-config.service.ts
+++ b/libs/transactions/src/lib/services/transactions-journey-config.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, TemplateRef } from '@angular/core';
 
 @Injectable()
 export class TransactionsJourneyConfiguration {
   pageSize = 20;
   slimMode = true;
+  additionalDetailsTpl: TemplateRef<any> | undefined = undefined;
 }

--- a/libs/transactions/src/lib/transactions-journey.component.html
+++ b/libs/transactions/src/lib/transactions-journey.component.html
@@ -1,0 +1,1 @@
+<bb-transactions-view></bb-transactions-view>

--- a/libs/transactions/src/lib/transactions-journey.component.spec.ts
+++ b/libs/transactions/src/lib/transactions-journey.component.spec.ts
@@ -1,0 +1,44 @@
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TransactionAdditionalDetailsTemplateDirective } from './directives/transaction-additional-details.directive';
+import { TransactionsJourneyConfiguration } from './services/transactions-journey-config.service';
+import { TransactionsJourneyComponent } from './transactions-journey.component';
+
+describe('TransactionsJourneyComponent', () => {
+    let fixture: ComponentFixture<WrapperComponent>;
+
+    const mockConfig: Partial<TransactionsJourneyConfiguration> = {
+        additionalDetailsTpl: undefined
+    }
+
+    @Component({
+        template: `
+            <bb-transactions-journey>
+                <ng-template bbTransactionAdditionalDetails>some-template</ng-template>
+            </bb-transactions-journey>
+        `
+    })
+    class WrapperComponent {}
+
+    beforeEach(async () => {
+        mockConfig.additionalDetailsTpl = undefined;
+
+        await TestBed.configureTestingModule({
+            declarations: [WrapperComponent, TransactionsJourneyComponent, TransactionAdditionalDetailsTemplateDirective],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [
+            { provide: TransactionsJourneyConfiguration, useValue: mockConfig },
+            ],
+        }).compileComponents();
+
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(WrapperComponent);
+        fixture.detectChanges();
+    });
+
+    it('should store provided template for additional details in config servie', () => {
+        expect(mockConfig.additionalDetailsTpl).toBeDefined();
+    });
+});

--- a/libs/transactions/src/lib/transactions-journey.component.ts
+++ b/libs/transactions/src/lib/transactions-journey.component.ts
@@ -1,5 +1,4 @@
 import { AfterContentChecked, Component, ContentChild } from '@angular/core';
-import { TransactionItem } from '@backbase/data-ang/transactions';
 import { TransactionAdditionalDetailsTemplateDirective } from './directives/transaction-additional-details.directive';
 import { TransactionsJourneyConfiguration } from './services/transactions-journey-config.service';
 
@@ -8,7 +7,7 @@ import { TransactionsJourneyConfiguration } from './services/transactions-journe
   templateUrl: 'transactions-journey.component.html',
 })
 export class TransactionsJourneyComponent implements AfterContentChecked {
-  @ContentChild(TransactionAdditionalDetailsTemplateDirective) additionalDetailsTpl?: TransactionAdditionalDetailsTemplateDirective<TransactionItem>;
+  @ContentChild(TransactionAdditionalDetailsTemplateDirective) additionalDetailsTpl?: TransactionAdditionalDetailsTemplateDirective;
 
   constructor(private readonly configService: TransactionsJourneyConfiguration) {}
   

--- a/libs/transactions/src/lib/transactions-journey.component.ts
+++ b/libs/transactions/src/lib/transactions-journey.component.ts
@@ -1,4 +1,5 @@
 import { AfterContentChecked, Component, ContentChild } from '@angular/core';
+import { TransactionItem } from '@backbase/data-ang/transactions';
 import { TransactionAdditionalDetailsTemplateDirective } from './directives/transaction-additional-details.directive';
 import { TransactionsJourneyConfiguration } from './services/transactions-journey-config.service';
 
@@ -7,7 +8,7 @@ import { TransactionsJourneyConfiguration } from './services/transactions-journe
   templateUrl: 'transactions-journey.component.html',
 })
 export class TransactionsJourneyComponent implements AfterContentChecked {
-  @ContentChild(TransactionAdditionalDetailsTemplateDirective) additionalDetailsTpl?: TransactionAdditionalDetailsTemplateDirective;
+  @ContentChild(TransactionAdditionalDetailsTemplateDirective) additionalDetailsTpl?: TransactionAdditionalDetailsTemplateDirective<TransactionItem>;
 
   constructor(private readonly configService: TransactionsJourneyConfiguration) {}
   

--- a/libs/transactions/src/lib/transactions-journey.component.ts
+++ b/libs/transactions/src/lib/transactions-journey.component.ts
@@ -1,0 +1,17 @@
+import { AfterContentChecked, Component, ContentChild } from '@angular/core';
+import { TransactionAdditionalDetailsTemplateDirective } from './directives/transaction-additional-details.directive';
+import { TransactionsJourneyConfiguration } from './services/transactions-journey-config.service';
+
+@Component({
+  selector: 'bb-transactions-journey',
+  templateUrl: 'transactions-journey.component.html',
+})
+export class TransactionsJourneyComponent implements AfterContentChecked {
+  @ContentChild(TransactionAdditionalDetailsTemplateDirective) additionalDetailsTpl?: TransactionAdditionalDetailsTemplateDirective;
+
+  constructor(private readonly configService: TransactionsJourneyConfiguration) {}
+  
+  ngAfterContentChecked() {
+    this.configService.additionalDetailsTpl = this.additionalDetailsTpl?.templateRef;
+  }
+}

--- a/libs/transactions/src/lib/transactions-journey.module.ts
+++ b/libs/transactions/src/lib/transactions-journey.module.ts
@@ -8,11 +8,13 @@ import { LoadingIndicatorModule } from '@backbase/ui-ang/loading-indicator';
 import { TextFilterComponent } from './components/text-filter/text-filter.component';
 import { TransactionItemComponent } from './components/transaction-item/transaction-item.component';
 import { TRANSLATIONS } from './constants/dynamic-translations';
+import { TransactionAdditionalDetailsTemplateDirective } from './directives/transaction-additional-details.directive';
 import { FilterTransactionsPipe } from './pipes/filter-transactions.pipe';
 import { ArrangementsService } from './services/arrangements.service';
 import { TransactionsJourneyConfiguration } from './services/transactions-journey-config.service';
 import { TransactionsRouteTitleResolverService } from './services/transactions-route-title-resolver.service';
 import { TransactionsHttpService } from './services/transactions.http.service';
+import { TransactionsJourneyComponent } from './transactions-journey.component';
 import { TransactionsViewComponent } from './views/transactions-view/transactions-view.component';
 
 const defaultRoute: Route = {
@@ -28,6 +30,8 @@ const defaultRoute: Route = {
 
 @NgModule({
   declarations: [
+    TransactionAdditionalDetailsTemplateDirective,
+    TransactionsJourneyComponent,
     TransactionsViewComponent,
     TransactionItemComponent,
     TextFilterComponent,
@@ -40,6 +44,10 @@ const defaultRoute: Route = {
     AmountModule,
     InputTextModule,
     LoadingIndicatorModule,
+  ],
+  exports: [
+    TransactionsJourneyComponent,
+    TransactionAdditionalDetailsTemplateDirective
   ],
   providers: [
     TransactionsHttpService,


### PR DESCRIPTION
> We want to provide customers the option to extend journey views, without the need to replace the entire view. For instance, when adding a small piece of html somewhere in the journey.

This is an example for the above, an extension slot replacement. 

The solution is based on an earlier POC by Armin
