### PR TITLE
POC single route replacement

### DIFF
--- a/apps/golden-sample-app/src/app/transfer/transfer-journey-bundle.module.ts
+++ b/apps/golden-sample-app/src/app/transfer/transfer-journey-bundle.module.ts
@@ -1,4 +1,5 @@
-import { NgModule } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
+import { Route } from '@angular/router';
 import {
   MakeTransferCommunicationService,
   MakeTransferJourneyConfiguration,
@@ -7,8 +8,21 @@ import {
 import { environment } from '../../environments/environment';
 import { JourneyCommunicationService } from '../services/journey-communication.service';
 
+@Component({
+  selector: 'app-my-custom-transfer-summary',
+  template: `
+    custom transfer summary
+  `,
+})
+export class MyCustomTransferSummaryComponent { }
+
+const override: Route = {
+  path: 'make-transfer-summary',
+  component: MyCustomTransferSummaryComponent,
+};
+
 @NgModule({
-  imports: [TransferJourneyModule.forRoot()],
+  imports: [TransferJourneyModule.forRoot({ routeOverrides: [override] })],
   providers: [
     {
       provide: MakeTransferJourneyConfiguration,

--- a/libs/transfer/src/lib/services/make-transfer-accounts.http.service.ts
+++ b/libs/transfer/src/lib/services/make-transfer-accounts.http.service.ts
@@ -1,13 +1,15 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Account } from '../model/Account';
 
 @Injectable()
 export class MakeTransferAccountHttpService {
-  currentAccount$: Observable<Account> = this.http.get<Account>(
-    '/api/accounts/current'
-  );
+  currentAccount$: Observable<Account> = of({
+    id: '00001',
+    name: 'my account name',
+    amount: 5690.76,
+  })
 
   constructor(private http: HttpClient) {}
 }

--- a/libs/transfer/src/lib/transfer-journey.module.ts
+++ b/libs/transfer/src/lib/transfer-journey.module.ts
@@ -98,11 +98,28 @@ const defaultRoute: Route = {
 })
 export class TransferJourneyModule {
   static forRoot(
-    data: { [key: string]: unknown; route: Route } = { route: defaultRoute }
+    data: { [key: string]: unknown; route?: Route, routeOverrides?: Route[] } = { route: defaultRoute }
   ): ModuleWithProviders<TransferJourneyModule> {
+
+    const route = data.route || defaultRoute;
+
+    // TODO: something generic instead of having this code in every journey
+    if (data.routeOverrides) {
+      data.routeOverrides.forEach(override => {
+        const foundRoute = route.children?.find(child => child.path === override.path)
+        
+        if (foundRoute) {
+          foundRoute.component = override.component;
+        }
+        // else try to find this recursively?
+
+        // last resort, maybe append this provided route to existing config?
+      })
+    }
+
     return {
       ngModule: TransferJourneyModule,
-      providers: [provideRoutes([data.route])],
+      providers: [provideRoutes([route])],
     };
   }
 }


### PR DESCRIPTION
POC for overriding one or more specific routes, instead of providing an entire new set of routing to the journey

This prevents copy/pasting the entire route config, and importing all routable components

 I assume this would make it less difficult to upgrade