### PR TITLE
IDWOJ-1244 - Remove usage of initLoginFlow following logout request

### DIFF
--- a/apps/golden-sample-app/src/app/user-context/user-context.component.ts
+++ b/apps/golden-sample-app/src/app/user-context/user-context.component.ts
@@ -24,6 +24,5 @@ export class UserContextComponent {
 
   logout() {
     this.authService.revokeTokenAndLogout();
-    this.authService.initLoginFlow();
   }
 }


### PR DESCRIPTION
This PR removes the usage of `initLoginFlow` method after `revokeTokenAndLogout` has been used.
Using this approach will result in the logout request being cancelled and a redirect directly to the IdP for login. While this causes the user no issues and does not cause any immediate concern relating to the session, it will not allow a redirect back to a public landing page within the app.
Instead, allow the logout process to proceed which will navigate to the IdP logout page and then back to the selected redirectUri in the provided AuthConfig. This page should then use an Auth Guard to navigate the user to the IdP, or to a public landing page if appropriate.