### PR TITLE
Add Auth Events Handler Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Do not copy-paste anything related to the authentication to your banking applica
 Check the example code in the [`app.module.ts`](https://github.com/Backbase/golden-sample-app/blob/main/apps/golden-sample-app/src/app/app.module.ts#L46), the related `AuthConfig` in the[`environment.ts`](https://github.com/Backbase/golden-sample-app/blob/main/apps/golden-sample-app/src/environments/environment.ts#L44) files, and the `APP_INITIALIZER` provider logic.
 Secure routes with `AuthGuard`s. We rely on <https://github.com/manfredsteyer/angular-oauth2-oidc>, check their documentation for more details.
 
+We've provided the `AuthEventsHandlerService` via the `APP_INITIALIZER` which will handle auth events from the above 3rd party library. This service is an example implementation of how we expect applications to handle auth events. It includes the following default settings:
+
+- The access token will be refreshed when it expires automatically.
+- When token refresh, code exchange, or session errors occur the user is automatically logged out.
+- A login using an invalid state parameter will be returned to the Auth server. This will likely result in a return to the application, however, in they will now have passed a valid state parameter.
+
 ## Generate an application
 
 Run `ng g @nrwl/angular:app my-app` to generate an application.

--- a/apps/golden-sample-app/src/app/app.module.ts
+++ b/apps/golden-sample-app/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { authConfig, environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { AuthEventsHandlerService } from './auth/auth-events-handler.service';
 import { AuthGuard } from './guards/auth.guard';
 import { LocaleSelectorModule } from './locale-selector/locale-selector.module';
 
@@ -72,9 +73,10 @@ import { LocaleSelectorModule } from './locale-selector/locale-selector.module';
     {
       provide: APP_INITIALIZER,
       multi: true,
-      deps: [OAuthService, CookieService],
+      deps: [OAuthService, CookieService, AuthEventsHandlerService],
       useFactory:
-        (oAuthService: OAuthService, cookieService: CookieService) => () => {
+        (oAuthService: OAuthService, cookieService: CookieService) =>
+        async () => {
           // Remove this if auth cookie is not needed for the app
           oAuthService.events.subscribe(({ type }) => {
             if (type === 'token_received' || type === 'token_refreshed') {
@@ -86,9 +88,7 @@ import { LocaleSelectorModule } from './locale-selector/locale-selector.module';
             }
           });
 
-          return oAuthService
-            .loadDiscoveryDocumentAndTryLogin()
-            .then(() => oAuthService.setupAutomaticSilentRefresh());
+          await oAuthService.loadDiscoveryDocumentAndTryLogin();
         },
     },
     {

--- a/apps/golden-sample-app/src/app/auth/auth-events-handler.service.spec.ts
+++ b/apps/golden-sample-app/src/app/auth/auth-events-handler.service.spec.ts
@@ -1,0 +1,146 @@
+import { OAuthEvent, OAuthService } from 'angular-oauth2-oidc';
+import { Subject, Subscription } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { AuthEventsHandlerService } from './auth-events-handler.service';
+
+export type WidePropertyTypes<T> = Partial<Record<keyof T, any>>;
+export const mock = <T>(overrides?: WidePropertyTypes<T>) =>
+  ({ ...overrides } as jest.Mocked<T>);
+describe('AuthEventsHandlerService', () => {
+  const getInstance = () => {
+    const events$$ = new Subject<OAuthEvent>();
+    const oAuthService = mock<OAuthService>({
+      events: events$$.asObservable(),
+      refreshToken: jest.fn(),
+      revokeTokenAndLogout: jest.fn(),
+      initLoginFlow: jest.fn(),
+    });
+    const service = new AuthEventsHandlerService(oAuthService);
+    const scheduler = new TestScheduler((a, e) => expect(a).toEqual(e));
+
+    return { service, oAuthService, events$$, scheduler };
+  };
+
+  describe('Document load', () => {
+    it('should not handle events if document is not loaded', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'token_expires' });
+        flush();
+      });
+
+      expect(oAuthService.refreshToken).not.toHaveBeenCalled();
+    });
+    it('should handle events when document is loaded', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'token_expires' });
+        flush();
+      });
+
+      expect(oAuthService.refreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Refreshing access tokens', () => {
+    it('should refresh an access token that expires', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'token_expires' });
+        flush();
+      });
+
+      expect(oAuthService.refreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Revoking tokens and logging out', () => {
+    it('should revoke tokens and log out the user when refresh token errors', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'token_refresh_error' });
+        flush();
+      });
+
+      expect(oAuthService.revokeTokenAndLogout).toHaveBeenCalledTimes(1);
+    });
+    it('should revoke tokens and log out the user when token errors', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'token_error' });
+        flush();
+      });
+
+      expect(oAuthService.revokeTokenAndLogout).toHaveBeenCalledTimes(1);
+    });
+    it('should revoke tokens and log out the user when code exchange errors', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'code_error' });
+        flush();
+      });
+
+      expect(oAuthService.revokeTokenAndLogout).toHaveBeenCalledTimes(1);
+    });
+    it('should revoke tokens and log out the user when the session errors', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'session_error' });
+        flush();
+      });
+
+      expect(oAuthService.revokeTokenAndLogout).toHaveBeenCalledTimes(1);
+    });
+    it('should revoke tokens and log out the user when the session is terminated', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'session_terminated' });
+        flush();
+      });
+
+      expect(oAuthService.revokeTokenAndLogout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Redirecting to login page', () => {
+    it('should redirect the user to the login page when they use an invalid nonce state', () => {
+      const { events$$, oAuthService, scheduler } = getInstance();
+
+      scheduler.run(({ flush }) => {
+        events$$.next({ type: 'discovery_document_loaded' });
+        events$$.next({ type: 'invalid_nonce_in_state' });
+        flush();
+      });
+
+      expect(oAuthService.initLoginFlow).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('#ngOnDestroy', () => {
+    it('should close events subscription', () => {
+      const { service } = getInstance();
+      const subscription: Subscription = (<any>service).eventsSubscription;
+
+      expect(subscription.closed).toBe(false);
+
+      service.ngOnDestroy();
+
+      expect(subscription.closed).toBe(true);
+    });
+  });
+});

--- a/apps/golden-sample-app/src/app/auth/auth-events-handler.service.ts
+++ b/apps/golden-sample-app/src/app/auth/auth-events-handler.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { OAuthEvent, OAuthService } from 'angular-oauth2-oidc';
+import { Subscription } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthEventsHandlerService implements OnDestroy {
+  private eventsSubscription: Subscription;
+  private documentLoaded = false;
+  constructor(private readonly oAuthService: OAuthService) {
+    this.eventsSubscription = this.getEventsSubscription();
+  }
+
+  /**
+   * Subscribes to the observable provided by the `angular-oauth2-oidc` service for auth events.
+   * Documentation for these events is provided via the library
+   * https://manfredsteyer.github.io/angular-oauth2-oidc/docs/additional-documentation/events.html
+   *
+   * The handling of events follow our best understanding of how we think applications should
+   * behave in each scenario.
+   *
+   * @returns a subscription to the auth service events
+   */
+  private getEventsSubscription() {
+    return this.oAuthService.events.subscribe({
+      next: (event: OAuthEvent) => {
+        // Don't handle any events if the document isn't loaded.
+        if (!this.documentLoaded && event.type !== 'discovery_document_loaded')
+          return;
+
+        switch (event.type) {
+          case 'discovery_document_loaded':
+            this.documentLoaded = true;
+            break;
+          // Expired access tokens are automatically refreshed.
+          case 'token_expires':
+            this.oAuthService.refreshToken();
+            break;
+          // Any authentication failure is treated as a terminal auth issue and the user is logged out.
+          case 'token_refresh_error':
+          case 'token_error':
+          case 'code_error':
+          case 'session_error':
+          case 'session_terminated':
+            this.oAuthService.revokeTokenAndLogout();
+            break;
+          // Invalid login process is treated as a threat and the user is returned to the login page.
+          // As the user is already logged in on the Auth server, they should just be navigated back to the app.
+          case 'invalid_nonce_in_state':
+            this.oAuthService.initLoginFlow();
+            break;
+        }
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.eventsSubscription.unsubscribe();
+  }
+}


### PR DESCRIPTION
Add Auth Events Handler Service to golden sample app which example how auth events could be used in the application to manage authentication of the user.

The auth events are used in the following manner:

- When the access token expires it is automatically refreshed
- When the token refresh, code exchange, or session errors the user is logged out
- When the state returned following login is invalid (bookmarked login url, or state manipulated) then the user is redirected back to the Auth server which may choose to log them in again.