### PR TITLE
Add the current application locale to the identity login request

### DIFF
--- a/apps/golden-sample-app/src/app/auth/auth-events-handler.service.ts
+++ b/apps/golden-sample-app/src/app/auth/auth-events-handler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID, OnDestroy } from '@angular/core';
 import { OAuthEvent, OAuthService } from 'angular-oauth2-oidc';
 import { Subscription } from 'rxjs';
 
@@ -8,7 +8,11 @@ import { Subscription } from 'rxjs';
 export class AuthEventsHandlerService implements OnDestroy {
   private eventsSubscription: Subscription;
   private documentLoaded = false;
-  constructor(private readonly oAuthService: OAuthService) {
+  constructor(
+    private readonly oAuthService: OAuthService,
+    @Inject(LOCALE_ID)
+    private readonly locale: string,
+  ) {
     this.eventsSubscription = this.getEventsSubscription();
   }
 
@@ -48,7 +52,7 @@ export class AuthEventsHandlerService implements OnDestroy {
           // Invalid login process is treated as a threat and the user is returned to the login page.
           // As the user is already logged in on the Auth server, they should just be navigated back to the app.
           case 'invalid_nonce_in_state':
-            this.oAuthService.initLoginFlow();
+            this.oAuthService.initLoginFlow(undefined, { 'ui_locales': this.locale });
             break;
         }
       },
@@ -67,7 +71,7 @@ export class AuthEventsHandlerService implements OnDestroy {
     if (this.oAuthService.hasValidAccessToken()) {
       this.oAuthService.revokeTokenAndLogout();
     } else {
-      this.oAuthService.initLoginFlow();
+      this.oAuthService.initLoginFlow(undefined, { 'ui_locales': this.locale });
     }
   }
 }

--- a/apps/golden-sample-app/src/app/auth/auth.guard.ts
+++ b/apps/golden-sample-app/src/app/auth/auth.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import {
   CanActivate,
   CanActivateChild,
@@ -15,8 +15,10 @@ import { map, Observable } from 'rxjs';
 export class AuthGuard implements CanActivate, CanLoad, CanActivateChild {
   constructor(
     private readonly authService: AuthService,
-    private readonly oAuthService: OAuthService
-  ) {}
+    private readonly oAuthService: OAuthService,
+    @Inject(LOCALE_ID)
+    private readonly locale: string,
+  ) { }
 
   canLoad(): Observable<boolean | UrlTree> {
     return this.redirectIfUnauthenticated();
@@ -41,7 +43,7 @@ export class AuthGuard implements CanActivate, CanLoad, CanActivateChild {
           return true;
         }
 
-        this.oAuthService.initLoginFlow();
+        this.oAuthService.initLoginFlow(undefined, { 'ui_locales': this.locale });
         return false;
       })
     );


### PR DESCRIPTION
This is needed to show the correct language for the login page.

E.g. for the URL https://identity.prd.sdbx.live.backbaseservices.com/auth/realms/retail/protocol/openid-connect/auth?response_type=code&client_id=bb-web-client&state=...&ui_locales=nl-NL will be selected NL locale:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/1961590/193206360-7d2b3609-b21f-4d78-a46b-1bc512af50b4.png">
