### PR TITLE
WF-830: test foundation-ang with all supported angular versions

### DIFF
--- a/.github/workflows/foundation-ang-trigger.yml
+++ b/.github/workflows/foundation-ang-trigger.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         angular_version: ['13', '12']
         include:
-          - angular_version: '13'
-            node_version: '16'
+          - angular_version: '12'
+            node_version: '14'
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/foundation-ang-trigger.yml
+++ b/.github/workflows/foundation-ang-trigger.yml
@@ -1,0 +1,53 @@
+name: Test foundation-ang
+run-name: 'Test foundation-ang ${{ github.event.inputs.foundation_ang_version }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      foundation_ang_version:
+        description: '@backbase/foundation-ang version'
+        required: false
+        default: latest
+
+jobs:
+  build:
+    name: 'Test with Angular ${{ matrix.angular_version }}'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        angular_version: ['13', '12']
+        include:
+          - angular_version: '13'
+            node_version: '16'
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          ref: 'angular@v${{ matrix.angular_version }}'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version || 16 }}
+          cache: 'npm'
+          registry-url: 'https://repo.backbase.com/artifactory/api/npm/npm-backbase/'
+          scope: '@backbase'
+
+      - name:  Install dependencies
+        run: npm install --legacy-peer-deps
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name:  Install @backbase/foundation-ang
+        run: npm install @backbase/foundation-ang@${{ github.event.inputs.foundation_ang_version }} --legacy-peer-deps
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build app
+        run: npm run build
+
+      - name: Unit tests
+        run: npm run test

--- a/.github/workflows/tag-angular-version.yml
+++ b/.github/workflows/tag-angular-version.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - test/angular-v12
+      - test/angular-v*
 
 jobs:
   tag:

--- a/.github/workflows/tag-angular-version.yml
+++ b/.github/workflows/tag-angular-version.yml
@@ -1,0 +1,27 @@
+name: Update Angular tag
+
+on:
+  push:
+    branches:
+      - main
+      - test/angular-v12
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Get Angular version
+        id: get-angular-version
+        run: |
+          version=$(node -p "require('./package-lock.json').dependencies['@angular/core'].version.split('.').shift()")
+          echo "::set-output name=version::$version"
+
+      - name: Update tag
+        run: |
+          tag='angular@v${{ steps.get-angular-version.outputs.version }}'
+          git tag $tag -f
+          git push origin $tag -f


### PR DESCRIPTION
The workflow job uses matrix parameters to checkout and test different git references that are linked with different Angular versions. Example https://github.com/Backbase/golden-sample-app/actions/runs/3246197479:

<img width="805" alt="image" src="https://user-images.githubusercontent.com/1961590/195726099-01a07e51-dbf8-4672-8f69-02326a7f3217.png">

There are two tags for two Angular versions: `angular@v12` and `angular@v13`. The workflow `tag-angular-version` is used to update these tags.
