### PR TITLE
WF-1899 Fix credentials link and update actions to Node 20

### DIFF
--- a/.github/actions/node-step/action.yml
+++ b/.github/actions/node-step/action.yml
@@ -22,7 +22,7 @@ runs:
     ##
     - name: Cache node modules
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-node-modules
       with:
@@ -36,9 +36,9 @@ runs:
           ${{ runner.os }}-
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: "npm"
         registry-url: "https://repo.backbase.com/api/npm/npm-backbase/"
         scope: "@backbase"

--- a/.github/workflows/foundation-ang-trigger.yml
+++ b/.github/workflows/foundation-ang-trigger.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'angular@v${{ matrix.angular_version }}'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node_version || 16 }}
+          node-version: ${{ matrix.node_version || 20 }}
           cache: 'npm'
           registry-url: 'https://repo.backbase.com/artifactory/api/npm/npm-backbase/'
           scope: '@backbase'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v3
+        uses: nrwl/nx-set-shas@v4
         with:
           main-branch-name: ${{ github.base_ref }}
 
@@ -45,7 +45,7 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.32.1-focal
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/node-step

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -47,8 +47,8 @@ jobs:
   update-angular-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
 
       - name: Get Angular version
         id: get-angular-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
           registry-url: 'https://repo.backbase.com/artifactory/api/npm/npm-backbase/'
           scope: '@backbase' 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run `npm run start` for a dev server. Navigate to <http://0.0.0.0:4200/>. The ap
 
 ## User credentials
 
-Credentials to login can be found [here](https://backbase.io/developers/documentation/ebp-sandbox/runtime-data/retail-user-credentials/).
+Credentials to login can be found [here](https://backbase.io/ebp-sandbox/user-credentials).
 
 ## Running the app with Mocks
 


### PR DESCRIPTION
1. Fixing the credentials link
2. Updating actions to use Node 20 because GHA need it. https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/