### PR TITLE
chore: update foundation-ang to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/router": "^17.1.3",
         "@backbase/accesscontrol-v3-http-ang": "^2.0.0",
         "@backbase/arrangement-manager-http-ang": "^4.0.0",
-        "@backbase/foundation-ang": "^10.1.0",
+        "@backbase/foundation-ang": "^10.3.4",
         "@backbase/identity-auth": "^4.0.0",
         "@backbase/initiate-payment-journey-ang": "5.1.0",
         "@backbase/internal-accessgroup-shared-data-access": "4.1.0",
@@ -3337,9 +3337,9 @@
       }
     },
     "node_modules/@backbase/foundation-ang": {
-      "version": "10.1.0",
-      "resolved": "https://repo.backbase.com/artifactory/api/npm/npm-backbase/@backbase/foundation-ang/-/@backbase/foundation-ang-10.1.0.tgz",
-      "integrity": "sha512-mo1b7gZC88hJTyHYhLMKa+DLNPuHzuZW53ndHeAl9hKvclxY4dLacJT1/hjrdfe//HgbICI0OuS6djQYRbXYQg==",
+      "version": "10.3.4",
+      "resolved": "https://repo.backbase.com/artifactory/api/npm/npm-backbase/@backbase/foundation-ang/-/@backbase/foundation-ang-10.3.4.tgz",
+      "integrity": "sha512-kHjD67bDt7mjaUtElmHBoz2mgnhSx8wPLOup0aOYi/n9wpO67wtNDJvhJ+2dK0x61gDBrv++Hgg/GVvmrAalTQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/router": "^17.1.3",
         "@backbase/accesscontrol-v3-http-ang": "^2.0.0",
         "@backbase/arrangement-manager-http-ang": "^4.0.0",
-        "@backbase/foundation-ang": "^10.3.4",
+        "@backbase/foundation-ang": "^10.3.5",
         "@backbase/identity-auth": "^4.0.0",
         "@backbase/initiate-payment-journey-ang": "5.1.0",
         "@backbase/internal-accessgroup-shared-data-access": "4.1.0",
@@ -3337,9 +3337,9 @@
       }
     },
     "node_modules/@backbase/foundation-ang": {
-      "version": "10.3.4",
-      "resolved": "https://repo.backbase.com/artifactory/api/npm/npm-backbase/@backbase/foundation-ang/-/@backbase/foundation-ang-10.3.4.tgz",
-      "integrity": "sha512-kHjD67bDt7mjaUtElmHBoz2mgnhSx8wPLOup0aOYi/n9wpO67wtNDJvhJ+2dK0x61gDBrv++Hgg/GVvmrAalTQ==",
+      "version": "10.3.5",
+      "resolved": "https://repo.backbase.com/artifactory/api/npm/npm-backbase/@backbase/foundation-ang/-/@backbase/foundation-ang-10.3.5.tgz",
+      "integrity": "sha512-ckoHU5F1z9yq6e3wGN0AsilZ/WuGmCAOTjTW04PLavnQMVNzuJeaPz6KBwgiQvqNCtnPykqxzlZaYD7LdSZ4zg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@angular/router": "^17.1.3",
     "@backbase/accesscontrol-v3-http-ang": "^2.0.0",
     "@backbase/arrangement-manager-http-ang": "^4.0.0",
-    "@backbase/foundation-ang": "^10.1.0",
+    "@backbase/foundation-ang": "^10.3.4",
     "@backbase/identity-auth": "^4.0.0",
     "@backbase/initiate-payment-journey-ang": "5.1.0",
     "@backbase/internal-accessgroup-shared-data-access": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@angular/router": "^17.1.3",
     "@backbase/accesscontrol-v3-http-ang": "^2.0.0",
     "@backbase/arrangement-manager-http-ang": "^4.0.0",
-    "@backbase/foundation-ang": "^10.3.4",
+    "@backbase/foundation-ang": "^10.3.5",
     "@backbase/identity-auth": "^4.0.0",
     "@backbase/initiate-payment-journey-ang": "5.1.0",
     "@backbase/internal-accessgroup-shared-data-access": "4.1.0",


### PR DESCRIPTION
This PR is for updating the `@backbase/foundation-ang` to the latest release v10.3.4