### PR TITLE
feat: Fix locale selector component to update language and UI correctly

### DIFF
--- a/apps/golden-sample-app/src/app/locale-selector/locale-selector.component.ts
+++ b/apps/golden-sample-app/src/app/locale-selector/locale-selector.component.ts
@@ -21,8 +21,11 @@ export class LocaleSelectorComponent implements OnInit {
     if (typeof value === 'string') {
       return;
     }
-
-    this.localeService.setLocale((value as Locale).code);
+    
+    if (value && 'code' in value) {
+      this.currentLanguage = value as Locale;
+      this.localeService.setLocale((value as Locale).code);
+    }
   }
 
   get language(): Locale | undefined {
@@ -35,7 +38,13 @@ export class LocaleSelectorComponent implements OnInit {
       []
     );
 
-    this.currentLanguage = this.findLocale(this.localeService.currentLocale);
+    const currentLocale = this.localeService.currentLocale;
+    this.currentLanguage = this.findLocale(currentLocale);
+    
+    // If current language wasn't found in the catalog, default to the first available
+    if (!this.currentLanguage && this.localesCatalog.length > 0) {
+      this.currentLanguage = this.localesCatalog[0];
+    }
   }
 
   private findLocale(locale: string): Locale | undefined {


### PR DESCRIPTION
This commit addresses the issue with the locale selector component not updating the application's locale and UI when a language is selected. The changes include:

1. Updating the `language` setter to properly set the current language and trigger locale change
2. Enhancing `ngOnInit` to handle cases where the current locale might not be found in the catalog
3. Ensuring the UI reflects the selected language

The modifications improve the locale selection process by:
- Updating the `currentLanguage` property when a new language is selected
- Providing a fallback to the first available language if the current locale is not found
- Ensuring the locale service is called with the correct language code