### PR TITLE
fix: minor fixes to remove build warnings

### DIFF
--- a/apps/golden-sample-app/tsconfig.app.json
+++ b/apps/golden-sample-app/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": []
+    "types": ["@angular/localize"]
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"],

--- a/libs/journey-bundles/custom-payment/src/lib/components/initiator/initiator.component.ts
+++ b/libs/journey-bundles/custom-payment/src/lib/components/initiator/initiator.component.ts
@@ -36,7 +36,7 @@ import { InitiatorService } from './initiator.service';
       >
       </bb-account-selector-ui>
 
-      @if (group?.touched && group?.invalid) {
+      @if (group.touched && group.invalid) {
       <div class="bb-input-validation-message">
         {{ requiredMessage }}
       </div>
@@ -70,10 +70,10 @@ export class InitiatorComponent implements OnInit, PaymentFormField {
 
   constructor() {
     this.debitAccounts$ = this.initiatorService.arrangements$;
+    this.setupInitiatorFormGroup(this.initiatorFormControls);
   }
 
   ngOnInit() {
-    this.setupInitiatorFormGroup(this.initiatorFormControls);
     this.requiredMessage = this.getValidationMessage('required');
   }
 

--- a/libs/journey-bundles/custom-payment/src/lib/custom-payment.config.ts
+++ b/libs/journey-bundles/custom-payment/src/lib/custom-payment.config.ts
@@ -1,5 +1,3 @@
-import '@angular/localize/init';
-
 import {
   CounterPartyFields,
   Frequencies,


### PR DESCRIPTION
- Remove `@angular/localize/init` from one of the libraries (and use types, and polyfills)
- Remove optional chainining

TODO:
plugin angular-sass still reports Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.